### PR TITLE
fix: Restore strict hex color validation requiring # prefix

### DIFF
--- a/internal/domain/category.go
+++ b/internal/domain/category.go
@@ -86,22 +86,9 @@ func (req *UpdateCategoryRequest) Validate() error {
 
 // isValidHexColor checks if the string is a valid hex color code
 func isValidHexColor(color string) bool {
-	// BUG: This validation is too lenient - it allows colors without # prefix
-	if len(color) != 6 && len(color) != 7 {
+	if len(color) != 7 {
 		return false
 	}
-	
-	// Allow both with and without # prefix (BUGGY)
-	if len(color) == 6 {
-		for i := 0; i < 6; i++ {
-			c := color[i]
-			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
-				return false
-			}
-		}
-		return true
-	}
-	
 	if color[0] != '#' {
 		return false
 	}


### PR DESCRIPTION
## Fix Description
This PR fixes the buggy color validation that was allowing hex colors without the required # prefix.

## Problem Fixed
- **Issue**: `isValidHexColor()` was accepting both `#FF0000` and `FF0000` formats
- **Root Cause**: Buggy implementation allowed colors without # prefix
- **Impact**: Validation tests were failing, allowing invalid color formats

## Solution
- **Restored strict validation** requiring # prefix
- **Fixed `isValidHexColor()`** to only accept `#RRGGBB` format
- **Rejects invalid formats** like `RRGGBB` (missing #)
- **Maintains data integrity** and validation standards

## Changes Made
- Modified `isValidHexColor()` function in `internal/domain/category.go`
- Removed buggy logic that accepted colors without # prefix
- Restored original strict validation requirements

## Test Results
- ✅ `TestIsValidHexColor/missing_hash` - Now passes
- ✅ All domain validation tests pass
- ✅ All HTTP tests pass
- ✅ F2P and P2P tests pass

## Validation Behavior
- ✅ `#FF0000` - Valid (with # prefix)
- ❌ `FF0000` - Invalid (missing # prefix)
- ❌ `#GG0000` - Invalid (invalid characters)
- ❌ `#FF00` - Invalid (wrong length)

## Related
- Fixes #4
- Resolves bug introduced in PR #3
- Maintains compatibility with Issue #1 requirements

This fix ensures proper data validation and test reliability.