### PR TITLE
fix: Add missing due date validation to UpdateTaskRequest

### DIFF
--- a/internal/domain/task.go
+++ b/internal/domain/task.go
@@ -111,6 +111,9 @@ func (r *UpdateTaskRequest) Validate() error {
 	if r.Priority != nil && !isValidPriority(*r.Priority) {
 		return errors.New("invalid priority")
 	}
+	if r.DueDate != nil && r.DueDate.Before(time.Now()) {
+		return errors.New("due date cannot be in the past")
+	}
 	return nil
 }
 

--- a/internal/domain/update_task_due_date_validation_test.go
+++ b/internal/domain/update_task_due_date_validation_test.go
@@ -1,0 +1,177 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestUpdateTaskRequestDueDateValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     UpdateTaskRequest
+		wantErr bool
+	}{
+		{
+			name: "valid request with future due date",
+			req: UpdateTaskRequest{
+				Title:       stringPtrForUpdate("Valid Task"),
+				Description: stringPtrForUpdate("Valid description"),
+				Priority:    priorityPtrForUpdate(PriorityMedium),
+				DueDate:     func() *time.Time { t := time.Now().AddDate(0, 0, 1); return &t }(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "request with past due date should fail validation",
+			req: UpdateTaskRequest{
+				Title:       stringPtrForUpdate("Task with Past Due Date"),
+				Description: stringPtrForUpdate("This should fail validation"),
+				Priority:    priorityPtrForUpdate(PriorityMedium),
+				DueDate:     func() *time.Time { t := time.Now().AddDate(0, 0, -1); return &t }(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "request with due date exactly now should fail validation",
+			req: UpdateTaskRequest{
+				Title:       stringPtrForUpdate("Task with Current Due Date"),
+				Description: stringPtrForUpdate("This should fail validation"),
+				Priority:    priorityPtrForUpdate(PriorityMedium),
+				DueDate:     func() *time.Time { t := time.Now(); return &t }(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "request with no due date should pass validation",
+			req: UpdateTaskRequest{
+				Title:       stringPtrForUpdate("Task without Due Date"),
+				Description: stringPtrForUpdate("This should pass validation"),
+				Priority:    priorityPtrForUpdate(PriorityMedium),
+				DueDate:     nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "request with only title update should pass validation",
+			req: UpdateTaskRequest{
+				Title: stringPtrForUpdate("Updated Title"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "request with only status update should pass validation",
+			req: UpdateTaskRequest{
+				Status: statusPtrForUpdate(StatusDoing),
+			},
+			wantErr: false,
+		},
+		{
+			name: "request with only priority update should pass validation",
+			req: UpdateTaskRequest{
+				Priority: priorityPtrForUpdate(PriorityHigh),
+			},
+			wantErr: false,
+		},
+		{
+			name: "request with only description update should pass validation",
+			req: UpdateTaskRequest{
+				Description: stringPtrForUpdate("Updated description"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "request with future due date and other fields should pass validation",
+			req: UpdateTaskRequest{
+				Title:       stringPtrForUpdate("Updated Task"),
+				Description: stringPtrForUpdate("Updated description"),
+				Status:      statusPtrForUpdate(StatusDoing),
+				Priority:    priorityPtrForUpdate(PriorityHigh),
+				DueDate:     func() *time.Time { t := time.Now().AddDate(0, 0, 2); return &t }(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "request with past due date and other fields should fail validation",
+			req: UpdateTaskRequest{
+				Title:       stringPtrForUpdate("Updated Task"),
+				Description: stringPtrForUpdate("Updated description"),
+				Status:      statusPtrForUpdate(StatusDoing),
+				Priority:    priorityPtrForUpdate(PriorityHigh),
+				DueDate:     func() *time.Time { t := time.Now().AddDate(0, 0, -2); return &t }(),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UpdateTaskRequest.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestUpdateTaskRequestDueDateValidationEdgeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     UpdateTaskRequest
+		wantErr bool
+	}{
+		{
+			name: "request with due date in the past by hours should fail validation",
+			req: UpdateTaskRequest{
+				Title:   stringPtrForUpdate("Task with Past Due Date"),
+				DueDate: func() *time.Time { t := time.Now().Add(-2 * time.Hour); return &t }(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "request with due date in the past by minutes should fail validation",
+			req: UpdateTaskRequest{
+				Title:   stringPtrForUpdate("Task with Past Due Date"),
+				DueDate: func() *time.Time { t := time.Now().Add(-30 * time.Minute); return &t }(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "request with due date in the future by minutes should pass validation",
+			req: UpdateTaskRequest{
+				Title:   stringPtrForUpdate("Task with Future Due Date"),
+				DueDate: func() *time.Time { t := time.Now().Add(30 * time.Minute); return &t }(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "request with due date in the future by hours should pass validation",
+			req: UpdateTaskRequest{
+				Title:   stringPtrForUpdate("Task with Future Due Date"),
+				DueDate: func() *time.Time { t := time.Now().Add(2 * time.Hour); return &t }(),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UpdateTaskRequest.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// Helper functions for UpdateTaskRequest tests
+func stringPtrForUpdate(s string) *string {
+	return &s
+}
+
+func priorityPtrForUpdate(p TaskPriority) *TaskPriority {
+	return &p
+}
+
+func statusPtrForUpdate(s TaskStatus) *TaskStatus {
+	return &s
+}


### PR DESCRIPTION
## Problem Fixed
`UpdateTaskRequest.Validate()` was missing due date validation, unlike `CreateTaskRequest.Validate()` and `Task.Validate()`. This inconsistency allowed users to update tasks with invalid due dates (e.g., past dates) through the update API endpoint.

## Issues Resolved
- **Missing Validation**: `UpdateTaskRequest.Validate()` didn't validate due dates at all
- **API Inconsistency**: Different validation behavior between create and update endpoints
- **Data Integrity**: Users could update tasks with past due dates
- **Business Logic**: Inconsistent task scheduling and reporting

## Solution Implemented
- **Added due date validation** to `UpdateTaskRequest.Validate()`
- **Consistent validation** across all request types (Create, Update, Task)
- **Proper error handling** with clear validation messages
- **Maintains flexibility** by only validating when DueDate is provided

## Changes Made
- Modified `UpdateTaskRequest.Validate()` to include due date validation
- Added validation: `if r.DueDate != nil && r.DueDate.Before(time.Now())`
- Returns error: `"due date cannot be in the past"` for invalid dates
- Only validates when DueDate is provided (nil is allowed)

## Test Coverage
- **2 Unit Test Functions**: Comprehensive validation tests
- **14 Test Cases**: Covering various update scenarios
- **Edge Cases**: Past dates by minutes, hours, and days
- **Update Scenarios**: Title only, status only, priority only, description only
- **Combined Updates**: Multiple fields with valid/invalid due dates
- **100% Pass Rate**: All tests pass successfully

## Validation Behavior
- ✅ Future dates: `time.Now().AddDate(0, 0, 1)` - Valid
- ❌ Past dates: `time.Now().AddDate(0, 0, -1)` - Invalid
- ❌ Current time: `time.Now()` - Invalid
- ✅ No due date: `nil` - Valid
- ✅ Other fields only: Title, status, priority, description - Valid

## Impact
- **Severity**: Medium - Data integrity issue resolved
- **API Consistency**: UpdateTaskRequest now has same validation as CreateTaskRequest
- **User Impact**: Users can no longer update tasks with invalid due dates
- **Business Impact**: Improved task scheduling and reporting accuracy

## Files Modified
- `internal/domain/task.go` - Added due date validation to UpdateTaskRequest.Validate()
- `internal/domain/update_task_due_date_validation_test.go` - Added comprehensive tests

## Priority
Medium - This affects API consistency and data integrity.

Fixes #11